### PR TITLE
fix tile gaps on movement

### DIFF
--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -29,7 +29,7 @@ export default class Game extends Phaser.Scene {
     tilemap.createLayer("Above", tileset);
 
     const playerSprite = this.add.sprite(0, 0, "player");
-    this.cameras.main.startFollow(playerSprite);
+    this.cameras.main.startFollow(playerSprite, true);
 
     const gridMovementConfig = {
       characters: [


### PR DESCRIPTION
Currently, when the player is moving some ugly gaps between the tiles show up in the tilemap. This can be fixed by telling the camera to round the pixels.